### PR TITLE
Use HTTP/1.1 in header example

### DIFF
--- a/index.html
+++ b/index.html
@@ -252,7 +252,7 @@
         </p>
         <aside class="example" title="Example GPC Request">
           <pre class="hljs http">
-            GET /something/here HTTP/2
+            GET /something/here HTTP/1.1
             Host: example.com
             Sec-GPC: 1
           </pre>
@@ -359,7 +359,7 @@
         </p>
         <aside class="example" title="example.org abides by GPC">
           <pre class="http">
-            GET /.well-known/gpc.json HTTP/2
+            GET /.well-known/gpc.json HTTP/1.1
             Host: example.org
             User-Agent: whatever
 


### PR DESCRIPTION
Formats like `GET /something/here HTTP/2` are invalid HTTP/2 or HTTP/1.1 syntax.

- For http2, use the :method and :path pseudo-headers.
