### PR TITLE
Fix inline `navigator` to use `<code>`

### DIFF
--- a/index.html
+++ b/index.html
@@ -520,7 +520,7 @@
     <section>
       <h2 id="privacy">Privacy Considerations</h2>
       <p>
-        Exposing a user's preference (in the HTTP header field or <pre class="js">navigator</pre> object)
+        Exposing a user's preference (in the HTTP header field or <code>navigator</code> object)
         potentially divides users into two groups in a way that might increase the information
         available for fingerprinting. This extra information is available unless the signal
         perfectly correlates with other signals. Depending on the browser and implementation, the GPC signal


### PR DESCRIPTION
Currently it renders like this, which doesn't look right:

![Screenshot 2024-11-21 at 19 17 16](https://github.com/user-attachments/assets/417b66d1-3853-4fe8-9b73-3dff76479923)
