### PR TITLE
Consolidate US legal info

### DIFF
--- a/index.html
+++ b/index.html
@@ -416,6 +416,13 @@
         rely upon informal guidance or enforcement actions to provide clarity on the scope of legal
         obligations around GPC signals.
       </p>
+      <p>
+        Other US state privacy laws, such as those in Virginia and Utah, give consumers new opt-out
+        rights around data sales and targeted advertising but are silent on the legal effect of
+        global opt-out signals. Regulators enforcing those statutes may determine that a user
+        activating a signal such as GPC may be sufficient to legally exercise opt-out rights in
+        those jurisdictions.
+      </p>
       <h3>Other Jurisdictions and Privacy Rights</h3>
       <p>
         GPC could potentially be used to indicate rights in other jurisdictions as well. For example, the
@@ -423,13 +430,6 @@
         Articles 7 and 21. Many other countries around the world have adopted affirmative privacy
         legislation — often modeled on the GDPR; a regulator in one of those countries could determine that
         GPC invokes a legal right that requires some response from a recipient.
-      </p>
-      <p>
-        Other US state privacy laws, such as those in Virginia and Utah, give consumers new opt-out
-        rights around data sales and targeted advertising but are silent on the legal effect of
-        global opt-out signals. Regulators enforcing those statutes may determine that a user
-        activating a signal such as GPC may be sufficient to legally exercise opt-out rights in
-        those jurisdictions.
       </p>
       <p>
         However, GPC is not necessarily intended to invoke every new privacy right in every


### PR DESCRIPTION
Section 5 of the spec discusses Legal Effects, with 5.1 covering United States privacy law and 5.2 covering other jurisdictions.

There is currently text in 5.2 discussing Virginia and Utah, so this PR proposes moving that under 5.1.

(As I mentioned in a previous meeting, I'm reviewing section 5 compared to the explainer, so that the detail of the changing legal landscape is covered more in the explainer. This is just a first step.)