### PR TITLE
Clarify scope of GPC

### DIFF
--- a/index.html
+++ b/index.html
@@ -395,8 +395,8 @@
     <section class="informative">
       <h2>Legal Effects</h2>
       <p>
-        The GPC signal was designed to allow users to take advantage of legal rights to <i>stop certain
-        sharing or processing of their data</i>. As such, the sending and receipt of a GPC signal may
+        The GPC signal was designed to allow users to take advantage of legal rights to stop certain
+        sharing or processing of their data. As such, the sending and receipt of a GPC signal may
         have legal effects, depending on factors such as the location of the individual sending the
         signal, the scope of the applicable law, as well as any separate agreement between the
         recipient of the signal and the individual. However, GPC is not necessarily intended to invoke
@@ -462,7 +462,7 @@
           preference for the Global Privacy Control value. While studies have shown that people do not
           want their data sold or shared, some jurisdictions have enacted "opt-out" legal frameworks
           where consumers have to take an affirmative action to express a [=preference=] to limit data
-          sharing of the use of their data for targeted advertising. GPC is designed to let users easily
+          sharing or the use of their data for targeted advertising. GPC is designed to let users easily
           take advantage of these laws.
         </p>
         <p>

--- a/index.html
+++ b/index.html
@@ -395,11 +395,12 @@
     <section class="informative">
       <h2>Legal Effects</h2>
       <p>
-        The GPC signal was designed to allow users to take advantage of legal rights to stop certain
-        sharing or processing of their data. As such, the sending and receipt of a GPC signal may
+        The GPC signal was designed to allow users to take advantage of legal rights to <i>stop certain
+        sharing or processing of their data</i>. As such, the sending and receipt of a GPC signal may
         have legal effects, depending on factors such as the location of the individual sending the
         signal, the scope of the applicable law, as well as any separate agreement between the
-        recipient of the signal and the individual. For additional details on legal effects, 
+        recipient of the signal and the individual. However, GPC is not necessarily intended to invoke
+        every new privacy right in every jurisdiction. For additional details on legal effects, 
         <a href="https://w3c.github.io/gpc/explainer" target="_blank">consult the Legal and
         Implementation Considerations Guide</a>.
       </p>
@@ -453,17 +454,22 @@
       <section>
         <h2>User Interface Language</h2>
         <p>
+          This document does not specify what information must be presented to a user before activating
+          GPC. When a user agent promotes a privacy feature or offers a privacy setting, it can make the
+          determination if it is appropriate to send GPC based on what has been disclosed to the user.
+          
           User agents SHOULD strive to represent what the user agent best believes to be the person's
           preference for the Global Privacy Control value. While studies have shown that people do not
           want their data sold or shared, some jurisdictions have enacted "opt-out" legal frameworks
           where consumers have to take an affirmative action to express a [=preference=] to limit data
-          sharing of the use of their data for targeted advertising.
+          sharing of the use of their data for targeted advertising. GPC is designed to let users easily
+          take advantage of these laws.
         </p>
         <p>
           Different jurisdictions have different prerequisites before a platform can enable a universal
-          opt-out. Many US states say that a user agent may not send a universal opt-out signal by "default,"
-          though at least one state has said that selecting a privacy focused user agent is a sufficient
-          indicator of user intent.
+          opt-out like GPC. Many US states say that a user agent may not send a universal opt-out signal by
+          "default," though at least one state has said that selecting a privacy focused user agent is a
+          sufficient indicator of user intent.
         </p>
         <p>
           Different jurisdictions may also have different rules for when companies can override or disregard


### PR DESCRIPTION
This PR is designed to

(1) Clarify to regulators the scope of rights intended to be invoked by GPC and
(2) Clarify the spec does not prescribe user interface language --- implementers should describe a privacy feature or setting they want to provide users and decide based on that whether it is appropriate to send GPC.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/gpc/pull/99.html" title="Last updated on Sep 11, 2025, 8:26 PM UTC (3f4028e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/gpc/99/7193414...3f4028e.html" title="Last updated on Sep 11, 2025, 8:26 PM UTC (3f4028e)">Diff</a>