### PR TITLE
Align all descriptions of GPC to say it's meant to restrict sale and sharing of data.

### DIFF
--- a/index.html
+++ b/index.html
@@ -143,7 +143,7 @@
         This specification is designed for this last category of laws and addresses the problem of the
         difficulty of scaling user choices by providing a way to universally signal to all website
         publishers, through an HTTP header
-        or the DOM, a person's assertion of their applicable rights to prevent the sale of their data,
+        or the DOM, a person's assertion of their applicable rights to prevent the sale of their data
         and the sharing of their data with third parties.
         This signal allows users to take advantage of specific provisions in some of these
         opt-out based laws, such as, for example, the provisions relating to "opt out preferences
@@ -396,10 +396,11 @@
       <h2>Legal Effects</h2>
       <p>
         The GPC signal was designed to allow users to take advantage of legal rights to stop certain
-        sale or sharing of their data. However, some jurisdictions have decided to also use it as a
-        prohibition against cross-site targeted advertising, even when such advertising does not
-        involve the selling or sharing of data. As such, the sending and receipt of a GPC signal may
-        have a variety of legal effects, depending on factors such as the location of the individual sending the
+        sale or sharing of their data. Some jurisdictions phrase this as opting out of
+        targeting advertisements using data that was shared between non-affiliated companies,
+        and that still falls into the opt out of sharing in general.
+        As such, the sending and receipt of a GPC signal may have a variety of legal effects,
+        depending on factors such as the location of the individual sending the
         signal, the scope of the applicable law, as well as any separate agreement between the
         recipient of the signal and the individual. For additional details on legal effects, 
         <a href="https://w3c.github.io/gpc/explainer" target="_blank">consult the Legal and
@@ -432,7 +433,7 @@
       </p>
       <p>
         Other US state privacy laws, such as those in Virginia and Utah, give consumers new opt-out
-        rights around data sales but are silent on the legal effect of
+        rights around data sales and sharing but are silent on the legal effect of
         global opt-out signals. Regulators enforcing those statutes may determine that a user
         activating a signal such as GPC may be sufficient to legally exercise opt-out rights in
         those jurisdictions.


### PR DESCRIPTION
This keeps the Abstract's definition of GPC, and aligns the other sections to match that and: the description on [globalprivacycontrol.org](https://globalprivacycontrol.org/#:~:text=The%20GPC%20signal%20will%20be%20intended%20to%20communicate%20a%20Do%20Not%20Sell%20request%20from%20a%20global%20privacy%20control), the UI wording that Firefox has chosen, and the description on extension sites like https://privacybadger.org/#What-is-Global-Privacy-Control. There's clearly appetite from some regulators to also have signals about cross-site advertising, cross-context advertising, and targeted advertising, but `Sec-GPC:1` isn't enough information to serve all of those purposes at the same time (#51).

This follows up on @michaelkleber's comment at https://github.com/w3c/gpc/issues/52#issuecomment-2819851415. It doesn't touch the UI guidance: if and when this part is merged, we can think about whether #99 is sufficient, or whether @michaelkleber or I should send a follow-up patch for that section.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#introduction, #definitions, #legal-effects, #united-states-privacy-law, #other-jurisdictions-and-privacy-rights, #user-interface-language
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/gpc/pull/102.html" title="Last updated on May 14, 2025, 6:48 PM UTC (67a8283)">Preview</a> (<a href="https://pr-preview.s3.amazonaws.com/jyasskin/gpc/pull/102.html#introduction" title="#introduction">#intro…</a>) (<a href="https://pr-preview.s3.amazonaws.com/jyasskin/gpc/pull/102.html#definitions" title="#definitions">#defin…</a>) (<a href="https://pr-preview.s3.amazonaws.com/jyasskin/gpc/pull/102.html#legal-effects" title="#legal-effects">#legal…</a>) (<a href="https://pr-preview.s3.amazonaws.com/jyasskin/gpc/pull/102.html#united-states-privacy-law" title="#united-states-privacy-law">#unite…</a>) (<a href="https://pr-preview.s3.amazonaws.com/jyasskin/gpc/pull/102.html#other-jurisdictions-and-privacy-rights" title="#other-jurisdictions-and-privacy-rights">#other…</a>) (<a href="https://pr-preview.s3.amazonaws.com/jyasskin/gpc/pull/102.html#user-interface-language" title="#user-interface-language">#user-…</a>) | <a href="https://pr-preview.s3.amazonaws.com/w3c/gpc/102/ab59f11...jyasskin:67a8283.html" title="Last updated on May 14, 2025, 6:48 PM UTC (67a8283)">Diff</a>