### PR TITLE
Changes lastUpdate to a more rational date

### DIFF
--- a/index.html
+++ b/index.html
@@ -386,7 +386,7 @@
 
             {
               "gpc": true,
-              "lastUpdate": "1997-03-10"
+              "lastUpdate": "2025-04-15"
             }
           </pre>
         </aside>


### PR DESCRIPTION
This reflects a solution to the conversation in #103 by giving the spec a more realistic and expected value for the lastUpdate property.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/gpc/pull/106.html" title="Last updated on Jul 10, 2025, 5:56 PM UTC (a21bc12)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/gpc/106/ab59f11...a21bc12.html" title="Last updated on Jul 10, 2025, 5:56 PM UTC (a21bc12)">Diff</a>