### PR TITLE
Edit to spec to clarify scope

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,12 +110,12 @@
       <h2>Introduction</h2>
       <p>
         Building websites today often involves relying on services provided by businesses other than
-        the one with which a person choses to interact. This result is a natural consequence of the
+        the one with which a person choses to interact. This result is a consequence of the
         increasing complexity of Web technology and of the division of labor between different
         services. While this architecture can be used in the service of better Web experiences,
         it can also be abused to violate privacy ([[?privacy-principles]]). While data can be shared
-        with service providers for limited operational purposes, it can also be shared with third
-        parties or used for behavioral targeting in ways that many users find objectionable.
+        with service providers for limited operational purposes, it can also be shared or used for
+        behavioral targeting in ways that many users find objectionable.
       </p>
       <p>
         Several different legal frameworks have been proposed or enacted by jurisdictions around
@@ -127,31 +127,25 @@
         Some laws and proposals grant users the right to request that their privacy be
         protected, including "opt out" requests that their data not be sold or shared beyond the
         business with which they intend to interact. Requiring that people manually express their
-        rights for each and every site they visit is, however, impractical.
+        rights for each and every site they visit is, however, impractical, and an imposition of 
+        "privacy labor" on people ([[?privacy-principles]]).
       </p>
-      <blockquote cite="https://oag.ca.gov/sites/all/files/agweb/pdfs/privacy/ccpa-fsor.pdf">
-        <p>
-          Given the ease and frequency by which personal information is collected and sold when a
-          consumer visits a website, consumers should have a similarly easy ability to request to
-          opt-out globally. This regulation offers consumers a global choice to opt-out of the sale
-          of personal information, as opposed to going website by website to make individual
-          requests with each business each time they use a new browser or a new device.
-          [[?CCPA-AG-FINAL-STATEMENT]]
-        </p>
-      </blockquote>
       <p>
         This specification is designed for this last category of laws and addresses the problem of the
         difficulty of scaling user choices by providing a way to universally signal to all website
         publishers, through an HTTP header
         or the DOM, a person's assertion of their applicable rights to prevent the sale of their data,
-        the sharing of their data with third parties, and the use of their data for cross-site targeted
+        the sharing of their data with third parties, and the use of their data for cross-context targeted
         advertising. This signal allows users to take advantage of specific provisions in some of these
         opt-out based laws, such as, for example, the provisions relating to "opt out preferences
-        signals" in the California Consumer Privacy Act. [[?CCPA-REGULATIONS]].
+        signals" in the California Consumer Privacy Act to stop the sale of sharing of personal information,
+        [[?CCPA-REGULATIONS]], or similar provisions for "universal opt-out mechanisms" in laws in Colorado
+        and other states to allow users to opt out of the sale of their information or its use for
+        cross-organization targeted advertising.
       </p>
       <p>
         The specification should not be interpreted as an endorsement of the opt-out model of
-        regulation — or cross-site tracking more broadly — or a rejecion of other models based on
+        regulation — or of cross-context tracking more broadly — or a rejecion of other models based on
         consent or data minimization. It is instead designed to make it possible to exercise the affirmative rights
         granted to users in certain jurisdictions.
       </p>
@@ -195,7 +189,7 @@
           expressed via this protocol.
         </p>
         <p>
-          User agents are expected to convey person [=preferences=] as accurately as they can. User
+          User agents are expected to convey a person's [=preferences=] as accurately as they can. User
           agents SHOULD strive to represent what the user agent best believes to be the person's
           [=preference=] for the Global Privacy Control value.
         </p>
@@ -412,7 +406,7 @@
         GPC was originally created to take advantage of new opt-out privacy laws in the United State.
         Starting with the enactment of the California Consumer Privacy Act in 2018, several U.S. states
         have passed privacy laws that give consumers the legal right to opt out of the sale or share of
-        their data, or the use of their data for cross-context targeted advertising. Many of those state
+        their data, or the use of their data for cross-organization targeted advertising. Many of those state
         laws make explicit provision for the exercise of those rights through universal opt-out mechanisms
         such as the GPC. At least four states have specifically identified GPC as a valid means to exercise
         legal opt-out rights. A minority of states provide for rulemaking procedures to allow regulators
@@ -430,8 +424,8 @@
       </p>
       <p>
         Other US state privacy laws, such as those in Virginia and Utah, give consumers new opt-out
-        rights around data sales and targeted advertising but are silent on the legal effect of
-        global opt-out signals. Regulators enforcing those statutes may determine that a user
+        rights around data sales and cross-organization targeted advertising but are silent on the legal
+        effect of global opt-out signals. Regulators enforcing those statutes may determine that a user
         activating a signal such as GPC may be sufficient to legally exercise opt-out rights in
         those jurisdictions.
       </p>
@@ -454,10 +448,10 @@
         <h2>User Interface Language</h2>
         <p>
           User agents SHOULD strive to represent what the user agent best believes to be the person's
-          preference for the Global Privacy Control value. While studies have shown that people do not
+          preference for the Global Privacy Control value. While studies have shown that most people do not
           want their data sold or shared, some jurisdictions have enacted "opt-out" legal frameworks
           where consumers have to take an affirmative action to express a [=preference=] to limit data
-          sharing of the use of their data for targeted advertising.
+          sharing of the use of their data for cross-organization targeted advertising.
         </p>
         <p>
           Different jurisdictions have different prerequisites before a platform can enable a universal

--- a/index.html
+++ b/index.html
@@ -155,7 +155,7 @@
       <p>
         A <dfn>do-not-sell-or-share interaction</dfn> is an interaction with a website in which the
         person is requesting that their data not be sold to or shared with any party other than the
-        one the person intends to interact with, or to have their data used for cross-site ad targeting,
+        one the person intends to interact with, or to have their data used for cross-context ad targeting,
         except as permitted by law.
       </p>
       <p>


### PR DESCRIPTION
Building on @jyasskin's amendments, I propose a compromise to clarify that GPC is intended to allow users to opt out of sale, sharing, or the use of their data for cross-context targeting. However, I note that the laws that have been enacted to date generally only restrict the use of cross-organization data for targeting.

This is also responsive to (#94) which sought greater consistency across the spec on intended scope.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/gpc/pull/107.html" title="Last updated on Jul 16, 2025, 4:07 PM UTC (06bba68)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/gpc/107/fbbecce...06bba68.html" title="Last updated on Jul 16, 2025, 4:07 PM UTC (06bba68)">Diff</a>