### PR TITLE
Return correct result from Get Global Privacy Control WebDriver command

### DIFF
--- a/index.html
+++ b/index.html
@@ -570,7 +570,7 @@
           |gpc| be true.
         <li><p>Otherwise, let |gpc| be false.
         <li><p>Let |result| be a JSON [=Object=] with property "<code>gpc</code>" set to |gpc|.
-        <li><p>Return [=success=] with data `null`.
+        <li><p>Return [=success=] with data `result`.
       </ol>
 
     </section>


### PR DESCRIPTION
Previously, the Get Global Privacy Control WebDriver extension command returned `null` rather than returning `result`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tcl3/gpc/pull/112.html" title="Last updated on Nov 5, 2025, 8:16 AM UTC (9f4438a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/gpc/112/80d1d7a...tcl3:9f4438a.html" title="Last updated on Nov 5, 2025, 8:16 AM UTC (9f4438a)">Diff</a>