### PR TITLE
Wording choice MAY --> can

### DIFF
--- a/index.html
+++ b/index.html
@@ -187,7 +187,7 @@
           <code>true</code> according to context.
         </p>
         <p>
-          In the absence of regulatory, legal, or other requirements, websites MAY interpret an
+          In the absence of regulatory, legal, or other requirements, websites can interpret an
           expressed Global Privacy Control [=preference=] as they find most appropriate for the given
           person, particularly as considered in light of the person's privacy expectations, context, and
           cultural circumstances. Likewise, websites might make use of other [=preference=] information


### PR DESCRIPTION
Per Issue #35 and discussion at WG call on 12/18, changing the word "MAY" to "can" in the following sentence to be factual instead of implying that we're granting optionality: 

"In the absence of regulatory, legal, or other requirements, websites MAY interpret an expressed Global Privacy Control preference as they find most appropriate for the given person, particularly as considered in light of the person's privacy expectations, context, and cultural circumstances."


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/gpc/pull/126.html" title="Last updated on Dec 18, 2025, 8:49 PM UTC (bab4aa9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/gpc/126/2dffb2b...bab4aa9.html" title="Last updated on Dec 18, 2025, 8:49 PM UTC (bab4aa9)">Diff</a>