### PR TITLE
Make spec consistent about same contexts rather than same sites

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,14 +120,14 @@
       <p>
         Several different legal frameworks have been proposed or enacted by jurisdictions around
         the world to address this concern. Some models rely upon user consent for tracking. Other
-        models based on the principle of data minimization simply prohibit certain data sharing or
+        models based on the principle of data minimization simply prohibit certain data sharing or 
         data processing entirely.
       </p>
       <p>
         Some laws and proposals grant users the right to request that their privacy be
         protected, including "opt out" requests that their data not be sold or shared beyond the
         business with which they intend to interact. Requiring that people manually express their
-        rights for each and every site they visit is, however, impractical, and an imposition of
+        rights for each and every site they visit is, however, impractical, and an imposition of 
         "privacy labor" on people ([[?privacy-principles]]).
       </p>
       <p>
@@ -401,7 +401,7 @@
         have legal effects, depending on factors such as the location of the individual sending the
         signal, the scope of the applicable law, as well as any separate agreement between the
         recipient of the signal and the individual. However, GPC is not necessarily intended to invoke
-        every new privacy right in every jurisdiction. For additional details on legal effects,
+        every new privacy right in every jurisdiction. For additional details on legal effects, 
         <a href="https://w3c.github.io/gpc/explainer" target="_blank">consult the Legal and
         Implementation Considerations Guide</a>.
       </p>
@@ -458,7 +458,7 @@
           This document does not specify what information must be presented to a user before activating
           GPC. When a user agent promotes a privacy feature or offers a privacy setting, it can make the
           determination if it is appropriate to send GPC based on what has been disclosed to the user.
-
+          
           User agents SHOULD strive to represent what the user agent best believes to be the person's
           preference for the Global Privacy Control value. While studies have shown that most people do not
           want their data sold or shared, some jurisdictions have enacted "opt-out" legal frameworks
@@ -503,10 +503,10 @@
       <p>
         Exposing a user's preference (in the HTTP header field or {{Window/navigator}} object)
         potentially divides users into two groups in a way that might increase the information
-        available for browser or device fingerprinting. This additional information is available
-        unless the signal perfectly correlates with other signals or is turned on in a
-        non-configurable setting. Thus, depending on the implementation, the GPC signal may impose
-        a privacy cost, though, one intended to be justified by the privacy benefit of sending the
+        available for browser or device fingerprinting. This additional information is available 
+        unless the signal perfectly correlates with other signals or is turned on in a 
+        non-configurable setting. Thus, depending on the implementation, the GPC signal may impose 
+        a privacy cost, though, one intended to be justified by the privacy benefit of sending the 
         signal.
       </p>
     </section>


### PR DESCRIPTION
This is a small change (aside from trailing spaces it's just editing one sentence) to make the spec consistently about contexts rather than sites. We can of course talk informally about websites and when technical limits force us into site-based distinctions, but it's important that the semantics of the GPC signal itself remain grounded in the notion of context.

Using sites instead of contexts would put GPC at odds with both the privacy architecture detailed in the Privacy Principles and the Vision for W3C's provisions on avoiding centralisation.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/darobin/gpc/pull/127.html" title="Last updated on Feb 4, 2026, 12:52 PM UTC (4f013f8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/gpc/127/2dffb2b...darobin:4f013f8.html" title="Last updated on Feb 4, 2026, 12:52 PM UTC (4f013f8)">Diff</a>